### PR TITLE
Hånterer deserialiseringsfeil.

### DIFF
--- a/src/main/kotlin/no/nav/helse/OmsorgsdageroverforingsoknadProsessering.kt
+++ b/src/main/kotlin/no/nav/helse/OmsorgsdageroverforingsoknadProsessering.kt
@@ -38,13 +38,12 @@ import no.nav.helse.prosessering.v1.PreprosseseringV1Service
 import no.nav.helse.prosessering.v1.asynkron.AsynkronProsesseringV1Service
 import no.nav.helse.prosessering.v1.asynkron.CleanupOverforeDager
 import no.nav.helse.prosessering.v1.asynkron.Data
-import no.nav.helse.prosessering.v1.asynkron.TopicEntryJson
+import no.nav.helse.prosessering.v1.asynkron.TopicEntry
 import no.nav.helse.prosessering.v1.overforeDager.PreprossesertOverforeDagerV1
 import no.nav.helse.prosessering.v1.overforeDager.SøknadOverføreDagerV1
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
-import java.nio.charset.Charset
 
 private val logger: Logger = LoggerFactory.getLogger("nav.OmsorgsdageroverforingsoknadProsessering")
 
@@ -141,9 +140,9 @@ fun omsorgsdageroverførningKonfigurertMapper(): ObjectMapper {
 }
 
 private fun Url.Companion.healthURL(baseUrl: URI) = Url.buildURL(baseUrl = baseUrl, pathParts = listOf("health"))
-internal fun TopicEntryJson.deserialiserTilSøknadOverføreDagerV1(): SøknadOverføreDagerV1 = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
-internal fun TopicEntryJson.deserialiserTilPreprossesertOverforeDagerV1():PreprossesertOverforeDagerV1  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
-internal fun TopicEntryJson.deserialiserTilCleanupOverforeDager():CleanupOverforeDager  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
+internal fun TopicEntry.deserialiserTilSøknadOverføreDagerV1(): SøknadOverføreDagerV1 = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
+internal fun TopicEntry.deserialiserTilPreprossesertOverforeDagerV1():PreprossesertOverforeDagerV1  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
+internal fun TopicEntry.deserialiserTilCleanupOverforeDager():CleanupOverforeDager  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
 
 
 internal fun Any.serialiserTilData() = Data(omsorgsdageroverførningKonfigurertMapper().writeValueAsString(this))

--- a/src/main/kotlin/no/nav/helse/OmsorgsdageroverforingsoknadProsessering.kt
+++ b/src/main/kotlin/no/nav/helse/OmsorgsdageroverforingsoknadProsessering.kt
@@ -140,9 +140,3 @@ fun omsorgsdageroverførningKonfigurertMapper(): ObjectMapper {
 }
 
 private fun Url.Companion.healthURL(baseUrl: URI) = Url.buildURL(baseUrl = baseUrl, pathParts = listOf("health"))
-internal fun TopicEntry.deserialiserTilSøknadOverføreDagerV1(): SøknadOverføreDagerV1 = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
-internal fun TopicEntry.deserialiserTilPreprossesertOverforeDagerV1():PreprossesertOverforeDagerV1  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
-internal fun TopicEntry.deserialiserTilCleanupOverforeDager():CleanupOverforeDager  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
-
-
-internal fun Any.serialiserTilData() = Data(omsorgsdageroverførningKonfigurertMapper().writeValueAsString(this))

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
@@ -13,11 +13,11 @@ import org.json.JSONObject
 
 internal data class Topic(
     val name: String,
-    val serDes: TopicEntrySerDes
+    val serDes: SerDes
 ) {
     val keySerializer = StringSerializer()
     private val keySerde = Serdes.String()
-    private val valueSerde = Serdes.serdeFrom(TopicEntrySerDes(), TopicEntrySerDes())
+    private val valueSerde = Serdes.serdeFrom(SerDes(), SerDes())
     val consumed = Consumed.with(keySerde, valueSerde)
     val produced = Produced.with(keySerde, valueSerde)
 }
@@ -25,28 +25,28 @@ internal data class Topic(
 internal object Topics {
     val MOTTATT_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-mottatt",
-        serDes = TopicEntrySerDes()
+        serDes = SerDes()
     )
 
     val PREPROSSESERT_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-preprossesert",
-        serDes = TopicEntrySerDes()
+        serDes = SerDes()
     )
 
 
     val CLEANUP_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-cleanup",
-        serDes = TopicEntrySerDes()
+        serDes = SerDes()
     )
 
     val JOURNALFORT_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-journalfort",
-        serDes = TopicEntrySerDes()
+        serDes = SerDes()
     )
 }
 
 data class Data(val rawJson: String)
-data class TopicEntryJson(val rawJson: String) {
+data class TopicEntry(val rawJson: String) {
     constructor(metadata: Metadata, data: Data) : this(
         JSONObject(
             mapOf(
@@ -81,9 +81,9 @@ data class CleanupOverforeDager(
 
 data class JournalfortOverforeDager(val journalpostId: String, val søknad: OmsorgspengerOverføringSøknad)
 
-class TopicEntrySerDes : Serializer<TopicEntryJson>, Deserializer<TopicEntryJson> {
+class SerDes : Serializer<TopicEntry>, Deserializer<TopicEntry> {
     override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) {}
     override fun close() {}
-    override fun serialize(topic: String, entry: TopicEntryJson): ByteArray = entry.rawJson.toByteArray()
-    override fun deserialize(topic: String, entry: ByteArray): TopicEntryJson = TopicEntryJson(String(entry))
+    override fun serialize(topic: String, entry: TopicEntry): ByteArray = entry.rawJson.toByteArray()
+    override fun deserialize(topic: String, entry: ByteArray): TopicEntry = TopicEntry(String(entry))
 }

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
@@ -76,7 +76,7 @@ data class TopicEntry(val rawJson: String) {
             mapOf(
                 "metadata" to JSONObject(
                     mapOf(
-                        "versjon" to metadata.version,
+                        "version" to metadata.version,
                         "correlationId" to metadata.correlationId,
                         "requestId" to metadata.requestId
                     )
@@ -90,7 +90,7 @@ data class TopicEntry(val rawJson: String) {
     private val metadataJson = requireNotNull(entityJson.getJSONObject("metadata"))
     private val dataJson = requireNotNull(entityJson.getJSONObject("data"))
     val metadata = Metadata(
-        version = requireNotNull(metadataJson.getInt("versjon")),
+        version = requireNotNull(metadataJson.getInt("version")),
         correlationId = requireNotNull(metadataJson.getString("correlationId")),
         requestId = requireNotNull(metadataJson.getString("requestId"))
     )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
@@ -1,96 +1,89 @@
 package no.nav.helse.prosessering.v1.asynkron
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.helse.dusseldorf.ktor.jackson.dusseldorfConfigured
 import no.nav.helse.prosessering.Metadata
 import no.nav.helse.prosessering.v1.overforeDager.PreprossesertOverforeDagerV1
-import no.nav.helse.prosessering.v1.overforeDager.SøknadOverføreDagerV1
-import no.nav.k9.søknad.omsorgspenger.OmsorgspengerSøknad
 import no.nav.k9.søknad.omsorgspenger.overføring.OmsorgspengerOverføringSøknad
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.common.serialization.Serializer
 import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.streams.kstream.Consumed
+import org.apache.kafka.streams.kstream.Produced
+import org.json.JSONObject
 
-data class TopicEntry<V>(val metadata: Metadata, val data: V)
-
-data class CleanupOverforeDager(val metadata: Metadata, val meldingV1: PreprossesertOverforeDagerV1, val journalførtMelding: JournalfortOverforeDager)
-
-data class JournalfortOverforeDager(val journalpostId: String, val søknad: OmsorgspengerOverføringSøknad)
-
-internal data class Topic<V>(
+internal data class Topic(
     val name: String,
-    val serDes : SerDes<V>
+    val serDes: TopicEntrySerDes
 ) {
     val keySerializer = StringSerializer()
-    val keySerde = Serdes.String()
-    val valueSerde = Serdes.serdeFrom(serDes, serDes)
+    private val keySerde = Serdes.String()
+    private val valueSerde = Serdes.serdeFrom(TopicEntrySerDes(), TopicEntrySerDes())
+    val consumed = Consumed.with(keySerde, valueSerde)
+    val produced = Produced.with(keySerde, valueSerde)
 }
 
 internal object Topics {
     val MOTTATT_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-mottatt",
-        serDes = MottattSoknadSerDesOverforeDager()
+        serDes = TopicEntrySerDes()
     )
+
     val PREPROSSESERT_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-preprossesert",
-        serDes = PreprossesertSerDesOverforeDager()
+        serDes = TopicEntrySerDes()
     )
+
+
     val CLEANUP_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-cleanup",
-        serDes = CleanupSerDesOverforeDager()
+        serDes = TopicEntrySerDes()
     )
+
     val JOURNALFORT_OVERFOREDAGER = Topic(
         name = "privat-overfore-omsorgsdager-soknad-journalfort",
-        serDes = JournalfortSerDesOverforeDager()
+        serDes = TopicEntrySerDes()
     )
 }
 
-internal abstract class SerDes<V> : Serializer<V>, Deserializer<V> {
-    protected val objectMapper = jacksonObjectMapper()
-        .dusseldorfConfigured()
-        .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE)
-        .configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false)
-    override fun serialize(topic: String?, data: V): ByteArray? {
-        return data?.let {
-            objectMapper.writeValueAsBytes(it)
-        }
-    }
+data class Data(val rawJson: String)
+data class TopicEntryJson(val rawJson: String) {
+    constructor(metadata: Metadata, data: Data) : this(
+        JSONObject(
+            mapOf(
+                "metadata" to JSONObject(
+                    mapOf(
+                        "versjon" to metadata.version,
+                        "correlationId" to metadata.correlationId,
+                        "requestId" to metadata.requestId
+                    )
+                ),
+                "data" to JSONObject(data.rawJson)
+            )
+        ).toString()
+    )
+
+    private val entityJson = JSONObject(rawJson)
+    private val metadataJson = requireNotNull(entityJson.getJSONObject("metadata"))
+    private val dataJson = requireNotNull(entityJson.getJSONObject("data"))
+    val metadata = Metadata(
+        version = requireNotNull(metadataJson.getInt("versjon")),
+        correlationId = requireNotNull(metadataJson.getString("correlationId")),
+        requestId = requireNotNull(metadataJson.getString("requestId"))
+    )
+    val data = Data(dataJson.toString())
+}
+
+data class CleanupOverforeDager(
+    val metadata: Metadata,
+    val meldingV1: PreprossesertOverforeDagerV1,
+    val journalførtMelding: JournalfortOverforeDager
+)
+
+data class JournalfortOverforeDager(val journalpostId: String, val søknad: OmsorgspengerOverføringSøknad)
+
+class TopicEntrySerDes : Serializer<TopicEntryJson>, Deserializer<TopicEntryJson> {
     override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) {}
     override fun close() {}
-}
-
-private class MottattSoknadSerDesOverforeDager: SerDes<TopicEntry<SøknadOverføreDagerV1>>() {
-    override fun deserialize(topic: String?, data: ByteArray?): TopicEntry<SøknadOverføreDagerV1>? {
-        return data?.let {
-            objectMapper.readValue<TopicEntry<SøknadOverføreDagerV1>>(it)
-        }
-    }
-}
-
-private class PreprossesertSerDesOverforeDager: SerDes<TopicEntry<PreprossesertOverforeDagerV1>>() {
-    override fun deserialize(topic: String?, data: ByteArray?): TopicEntry<PreprossesertOverforeDagerV1>? {
-        return data?.let {
-            objectMapper.readValue(it)
-        }
-    }
-}
-
-private class CleanupSerDesOverforeDager: SerDes<TopicEntry<CleanupOverforeDager>>() {
-    override fun deserialize(topic: String?, data: ByteArray?): TopicEntry<CleanupOverforeDager>? {
-        return data?.let {
-            objectMapper.readValue(it)
-        }
-    }
-}
-
-private class JournalfortSerDesOverforeDager: SerDes<TopicEntry<JournalfortOverforeDager>>() {
-    override fun deserialize(topic: String?, data: ByteArray?): TopicEntry<JournalfortOverforeDager>? {
-        return data?.let {
-            objectMapper.readValue(it)
-        }
-    }
+    override fun serialize(topic: String, entry: TopicEntryJson): ByteArray = entry.rawJson.toByteArray()
+    override fun deserialize(topic: String, entry: ByteArray): TopicEntryJson = TopicEntryJson(String(entry))
 }

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topics.kt
@@ -1,7 +1,10 @@
 package no.nav.helse.prosessering.v1.asynkron
 
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.helse.omsorgsdageroverførningKonfigurertMapper
 import no.nav.helse.prosessering.Metadata
 import no.nav.helse.prosessering.v1.overforeDager.PreprossesertOverforeDagerV1
+import no.nav.helse.prosessering.v1.overforeDager.SøknadOverføreDagerV1
 import no.nav.k9.søknad.omsorgspenger.overføring.OmsorgspengerOverføringSøknad
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serdes
@@ -46,6 +49,27 @@ internal object Topics {
 }
 
 data class Data(val rawJson: String)
+data class CleanupOverforeDager(
+    val metadata: Metadata,
+    val meldingV1: PreprossesertOverforeDagerV1,
+    val journalførtMelding: JournalfortOverforeDager
+)
+
+class SerDes : Serializer<TopicEntry>, Deserializer<TopicEntry> {
+    override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) {}
+    override fun close() {}
+    override fun serialize(topic: String, entry: TopicEntry): ByteArray = entry.rawJson.toByteArray()
+    override fun deserialize(topic: String, entry: ByteArray): TopicEntry = TopicEntry(String(entry))
+}
+
+internal fun TopicEntry.deserialiserTilSøknadOverføreDagerV1(): SøknadOverføreDagerV1 = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
+internal fun TopicEntry.deserialiserTilPreprossesertOverforeDagerV1():PreprossesertOverforeDagerV1  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
+internal fun TopicEntry.deserialiserTilCleanupOverforeDager():CleanupOverforeDager  = omsorgsdageroverførningKonfigurertMapper().readValue(data.rawJson)
+internal fun Any.serialiserTilData() = Data(omsorgsdageroverførningKonfigurertMapper().writeValueAsString(this))
+
+
+data class JournalfortOverforeDager(val journalpostId: String, val søknad: OmsorgspengerOverføringSøknad)
+
 data class TopicEntry(val rawJson: String) {
     constructor(metadata: Metadata, data: Data) : this(
         JSONObject(
@@ -71,19 +95,4 @@ data class TopicEntry(val rawJson: String) {
         requestId = requireNotNull(metadataJson.getString("requestId"))
     )
     val data = Data(dataJson.toString())
-}
-
-data class CleanupOverforeDager(
-    val metadata: Metadata,
-    val meldingV1: PreprossesertOverforeDagerV1,
-    val journalførtMelding: JournalfortOverforeDager
-)
-
-data class JournalfortOverforeDager(val journalpostId: String, val søknad: OmsorgspengerOverføringSøknad)
-
-class SerDes : Serializer<TopicEntry>, Deserializer<TopicEntry> {
-    override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) {}
-    override fun close() {}
-    override fun serialize(topic: String, entry: TopicEntry): ByteArray = entry.rawJson.toByteArray()
-    override fun deserialize(topic: String, entry: ByteArray): TopicEntry = TopicEntry(String(entry))
 }

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topology.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topology.kt
@@ -16,11 +16,11 @@ private object StreamCounter {
     internal fun feil(name: String) = counter.labels(name, "FEIL").inc()
 }
 
-internal fun <BEFORE, AFTER>process(
+internal fun process(
     name: String,
     soknadId: String,
-    entry: TopicEntry<BEFORE>,
-    block: suspend() -> AFTER) : TopicEntry<AFTER> {
+    entry: TopicEntryJson,
+    block: suspend() -> Data) : TopicEntryJson {
     return runBlocking(MDCContext(mapOf(
         "correlation_id" to entry.metadata.correlationId,
         "request_id" to entry.metadata.requestId,
@@ -37,7 +37,7 @@ internal fun <BEFORE, AFTER>process(
             throw cause
         }
         StreamCounter.ok(name)
-        TopicEntry(
+        TopicEntryJson(
             metadata = entry.metadata,
             data = processed
         )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topology.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topology.kt
@@ -19,8 +19,8 @@ private object StreamCounter {
 internal fun process(
     name: String,
     soknadId: String,
-    entry: TopicEntryJson,
-    block: suspend() -> Data) : TopicEntryJson {
+    entry: TopicEntry,
+    block: suspend() -> Data) : TopicEntry {
     return runBlocking(MDCContext(mapOf(
         "correlation_id" to entry.metadata.correlationId,
         "request_id" to entry.metadata.requestId,
@@ -37,7 +37,7 @@ internal fun process(
             throw cause
         }
         StreamCounter.ok(name)
-        TopicEntryJson(
+        TopicEntry(
             metadata = entry.metadata,
             data = processed
         )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/CleanupStreamOverforeDager.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/CleanupStreamOverforeDager.kt
@@ -2,21 +2,18 @@ package no.nav.helse.prosessering.v1.asynkron.overforeDager
 
 import no.nav.helse.CorrelationId
 import no.nav.helse.aktoer.AktørId
+import no.nav.helse.deserialiserTilCleanupOverforeDager
 import no.nav.helse.dokument.DokumentService
 import no.nav.helse.kafka.KafkaConfig
 import no.nav.helse.kafka.ManagedKafkaStreams
 import no.nav.helse.kafka.ManagedStreamHealthy
 import no.nav.helse.kafka.ManagedStreamReady
-import no.nav.helse.prosessering.v1.asynkron.*
-import no.nav.helse.prosessering.v1.asynkron.Topic
 import no.nav.helse.prosessering.v1.asynkron.Topics
 import no.nav.helse.prosessering.v1.asynkron.process
+import no.nav.helse.serialiserTilData
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
-import org.apache.kafka.streams.kstream.Consumed
-import org.apache.kafka.streams.kstream.Produced
 import org.slf4j.LoggerFactory
-import java.time.ZonedDateTime
 
 internal class CleanupStreamOverforeDager(
     kafkaConfig: KafkaConfig,
@@ -38,28 +35,27 @@ internal class CleanupStreamOverforeDager(
 
         private fun topology(dokumentService: DokumentService): Topology {
             val builder = StreamsBuilder()
-            val fraCleanup: Topic<TopicEntry<CleanupOverforeDager>> = Topics.CLEANUP_OVERFOREDAGER
-            val tilJournalfort: Topic<TopicEntry<JournalfortOverforeDager>> = Topics.JOURNALFORT_OVERFOREDAGER
+            val fraCleanup = Topics.CLEANUP_OVERFOREDAGER
+            val tilJournalfort= Topics.JOURNALFORT_OVERFOREDAGER
 
             builder
-                .stream<String, TopicEntry<CleanupOverforeDager>>(
-                    fraCleanup.name, Consumed.with(fraCleanup.keySerde, fraCleanup.valueSerde)
-                )
+                .stream(fraCleanup.name, fraCleanup.consumed)
                 .filter { _, entry -> 2 == entry.metadata.version }
                 .mapValues { soknadId, entry ->
                     process(NAME, soknadId, entry) {
+                        val cleanupMelding = entry.deserialiserTilCleanupOverforeDager()
                         logger.info("Sletter overfore dager dokumenter.")
                         dokumentService.slettDokumeter(
-                            urlBolks = entry.data.meldingV1.dokumentUrls,
-                            aktørId = AktørId(entry.data.meldingV1.søker.aktørId),
+                            urlBolks = cleanupMelding.meldingV1.dokumentUrls,
+                            aktørId = AktørId(cleanupMelding.meldingV1.søker.aktørId),
                             correlationId = CorrelationId(entry.metadata.correlationId)
                         )
                         logger.info("Dokumenter slettet.")
                         logger.info("Videresender journalført overføre dager melding")
-                        entry.data.journalførtMelding
+                        cleanupMelding.journalførtMelding.serialiserTilData()
                     }
                 }
-                .to(tilJournalfort.name, Produced.with(tilJournalfort.keySerde, tilJournalfort.valueSerde))
+                .to(tilJournalfort.name, tilJournalfort.produced)
             return builder.build()
         }
     }

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/CleanupStreamOverforeDager.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/CleanupStreamOverforeDager.kt
@@ -2,15 +2,15 @@ package no.nav.helse.prosessering.v1.asynkron.overforeDager
 
 import no.nav.helse.CorrelationId
 import no.nav.helse.aktoer.AktørId
-import no.nav.helse.deserialiserTilCleanupOverforeDager
 import no.nav.helse.dokument.DokumentService
 import no.nav.helse.kafka.KafkaConfig
 import no.nav.helse.kafka.ManagedKafkaStreams
 import no.nav.helse.kafka.ManagedStreamHealthy
 import no.nav.helse.kafka.ManagedStreamReady
 import no.nav.helse.prosessering.v1.asynkron.Topics
+import no.nav.helse.prosessering.v1.asynkron.deserialiserTilCleanupOverforeDager
 import no.nav.helse.prosessering.v1.asynkron.process
-import no.nav.helse.serialiserTilData
+import no.nav.helse.prosessering.v1.asynkron.serialiserTilData
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/JournalforingsStreamOverforeDager.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/JournalforingsStreamOverforeDager.kt
@@ -2,7 +2,6 @@ package no.nav.helse.prosessering.v1.asynkron.overforeDager
 
 import no.nav.helse.CorrelationId
 import no.nav.helse.aktoer.AktørId
-import no.nav.helse.deserialiserTilPreprossesertOverforeDagerV1
 import no.nav.helse.joark.JoarkGateway
 import no.nav.helse.kafka.KafkaConfig
 import no.nav.helse.kafka.ManagedKafkaStreams
@@ -14,7 +13,6 @@ import no.nav.helse.prosessering.v1.asynkron.Topics
 import no.nav.helse.prosessering.v1.asynkron.process
 import no.nav.helse.prosessering.v1.overforeDager.Fosterbarn
 import no.nav.helse.prosessering.v1.overforeDager.PreprossesertSøker
-import no.nav.helse.serialiserTilData
 import no.nav.k9.søknad.felles.Barn
 import no.nav.k9.søknad.felles.NorskIdentitetsnummer
 import no.nav.k9.søknad.felles.Søker

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/PreprosseseringStreamOverforeDager.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/PreprosseseringStreamOverforeDager.kt
@@ -1,14 +1,14 @@
 package no.nav.helse.prosessering.v1.asynkron.overforeDager
 
-import no.nav.helse.deserialiserTilSøknadOverføreDagerV1
 import no.nav.helse.kafka.KafkaConfig
 import no.nav.helse.kafka.ManagedKafkaStreams
 import no.nav.helse.kafka.ManagedStreamHealthy
 import no.nav.helse.kafka.ManagedStreamReady
 import no.nav.helse.prosessering.v1.PreprosseseringV1Service
 import no.nav.helse.prosessering.v1.asynkron.Topics
+import no.nav.helse.prosessering.v1.asynkron.deserialiserTilSøknadOverføreDagerV1
 import no.nav.helse.prosessering.v1.asynkron.process
-import no.nav.helse.serialiserTilData
+import no.nav.helse.prosessering.v1.asynkron.serialiserTilData
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/PreprosseseringStreamOverforeDager.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/overforeDager/PreprosseseringStreamOverforeDager.kt
@@ -1,30 +1,27 @@
 package no.nav.helse.prosessering.v1.asynkron.overforeDager
 
+import no.nav.helse.deserialiserTilSøknadOverføreDagerV1
 import no.nav.helse.kafka.KafkaConfig
 import no.nav.helse.kafka.ManagedKafkaStreams
 import no.nav.helse.kafka.ManagedStreamHealthy
 import no.nav.helse.kafka.ManagedStreamReady
 import no.nav.helse.prosessering.v1.PreprosseseringV1Service
-import no.nav.helse.prosessering.v1.asynkron.TopicEntry
 import no.nav.helse.prosessering.v1.asynkron.Topics
 import no.nav.helse.prosessering.v1.asynkron.process
-import no.nav.helse.prosessering.v1.overforeDager.SøknadOverføreDagerV1
+import no.nav.helse.serialiserTilData
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
-import org.apache.kafka.streams.kstream.Consumed
-import org.apache.kafka.streams.kstream.Produced
 import org.slf4j.LoggerFactory
-import java.time.ZonedDateTime
 
 internal class PreprosseseringStreamOverforeDager(
-        preprosseseringV1Service: PreprosseseringV1Service,
-        kafkaConfig: KafkaConfig
+    preprosseseringV1Service: PreprosseseringV1Service,
+    kafkaConfig: KafkaConfig
 ) {
     private val stream = ManagedKafkaStreams(
-            name = NAME,
-            properties = kafkaConfig.stream(NAME),
-            topology = topology(preprosseseringV1Service),
-            unreadyAfterStreamStoppedIn = kafkaConfig.unreadyAfterStreamStoppedIn
+        name = NAME,
+        properties = kafkaConfig.stream(NAME),
+        topology = topology(preprosseseringV1Service),
+        unreadyAfterStreamStoppedIn = kafkaConfig.unreadyAfterStreamStoppedIn
     )
 
     internal val ready = ManagedStreamReady(stream)
@@ -41,23 +38,20 @@ internal class PreprosseseringStreamOverforeDager(
             val tilPreprossesert = Topics.PREPROSSESERT_OVERFOREDAGER
 
             builder
-                    .stream<String, TopicEntry<SøknadOverføreDagerV1>>(
-                            fromMottatt.name,
-                            Consumed.with(fromMottatt.keySerde, fromMottatt.valueSerde)
-                    )
-                    .filter { _, entry -> 2 == entry.metadata.version }
-                    .mapValues { soknadId, entry ->
-                        process(NAME, soknadId, entry) {
-                            logger.info("Preprosesserer søknad for overføring av dager.")
-                            val preprossesertMelding = preprosseseringV1Service.preprosseserOverforeDager(
-                                    melding = entry.data,
-                                    metadata = entry.metadata
-                            )
-                            logger.info("Preprossesering søknad overføre dager ferdig.")
-                            preprossesertMelding
-                        }
+                .stream(fromMottatt.name, fromMottatt.consumed)
+                .filter { _, entry -> 2 == entry.metadata.version }
+                .mapValues { soknadId, entry ->
+                    process(NAME, soknadId, entry) {
+                        logger.info("Preprosesserer søknad for overføring av dager.")
+                        val preprossesertMelding = preprosseseringV1Service.preprosseserOverforeDager(
+                            melding = entry.deserialiserTilSøknadOverføreDagerV1(),
+                            metadata = entry.metadata
+                        )
+                        logger.info("Preprossesering søknad overføre dager ferdig.")
+                        preprossesertMelding.serialiserTilData()
                     }
-                    .to(tilPreprossesert.name, Produced.with(tilPreprossesert.keySerde, tilPreprossesert.valueSerde))
+                }
+                .to(tilPreprossesert.name, tilPreprossesert.produced)
             return builder.build()
         }
     }

--- a/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
+++ b/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
@@ -4,7 +4,7 @@ import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.helse.prosessering.Metadata
 import no.nav.helse.prosessering.v1.asynkron.Data
-import no.nav.helse.prosessering.v1.asynkron.TopicEntryJson
+import no.nav.helse.prosessering.v1.asynkron.TopicEntry
 import no.nav.helse.prosessering.v1.asynkron.Topics.CLEANUP_OVERFOREDAGER
 import no.nav.helse.prosessering.v1.asynkron.Topics.JOURNALFORT_OVERFOREDAGER
 import no.nav.helse.prosessering.v1.asynkron.Topics.MOTTATT_OVERFOREDAGER
@@ -104,12 +104,12 @@ fun KafkaConsumer<String, String>.hentJournalførtMeldingOverforeDager(
     throw IllegalStateException("Fant ikke opprettet oppgave for søknad $soknadId etter $maxWaitInSeconds sekunder.")
 }
 
-fun KafkaProducer<String, TopicEntryJson>.leggTilMottak(soknad: SøknadOverføreDagerV1) {
+fun KafkaProducer<String, TopicEntry>.leggTilMottak(soknad: SøknadOverføreDagerV1) {
     send(
         ProducerRecord(
             MOTTATT_OVERFOREDAGER.name,
             soknad.søknadId,
-            TopicEntryJson(
+            TopicEntry(
                 metadata = Metadata(
                     version = 2,
                     correlationId = UUID.randomUUID().toString(),

--- a/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
+++ b/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
@@ -3,7 +3,8 @@ package no.nav.helse
 import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.helse.prosessering.Metadata
-import no.nav.helse.prosessering.v1.asynkron.TopicEntry
+import no.nav.helse.prosessering.v1.asynkron.Data
+import no.nav.helse.prosessering.v1.asynkron.TopicEntryJson
 import no.nav.helse.prosessering.v1.asynkron.Topics.CLEANUP_OVERFOREDAGER
 import no.nav.helse.prosessering.v1.asynkron.Topics.JOURNALFORT_OVERFOREDAGER
 import no.nav.helse.prosessering.v1.asynkron.Topics.MOTTATT_OVERFOREDAGER
@@ -103,18 +104,18 @@ fun KafkaConsumer<String, String>.hentJournalførtMeldingOverforeDager(
     throw IllegalStateException("Fant ikke opprettet oppgave for søknad $soknadId etter $maxWaitInSeconds sekunder.")
 }
 
-fun KafkaProducer<String, TopicEntry<SøknadOverføreDagerV1>>.leggTilMottak(soknad: SøknadOverføreDagerV1) {
+fun KafkaProducer<String, TopicEntryJson>.leggTilMottak(soknad: SøknadOverføreDagerV1) {
     send(
         ProducerRecord(
             MOTTATT_OVERFOREDAGER.name,
             soknad.søknadId,
-            TopicEntry(
+            TopicEntryJson(
                 metadata = Metadata(
                     version = 2,
                     correlationId = UUID.randomUUID().toString(),
                     requestId = UUID.randomUUID().toString()
                 ),
-                data = soknad
+                data = Data(omsorgsdageroverførningKonfigurertMapper().writeValueAsString(soknad))
             )
         )
     ).get()


### PR DESCRIPTION
Deserialisering av gamle søknadsformater skaper problemer. Det er vanskelig å filterere, uten at kafka prøver å deserialisere først.
Implementasjonen refaktorer kodebasen til å kun serialisere metadata på melding, og lagrer selve søknaden som en json string.
Deretter serialiserer vi selve søknaden.